### PR TITLE
Add Download support to all Searches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
 script:
   - docker run -it -d --rm --name tripal -v "$(pwd)":/modules/chado_custom_search statonlab/tripal3
-  - sleep 30 # We pause here so postgres and apache complete booting up
+  - sleep 45 # We pause here so postgres and apache complete booting up
   - docker exec -it tripal drush pm-enable -y chado_custom_search
   - docker exec -it tripal yum install -y php-pecl-xdebug.x86_64
   - docker exec -it tripal bash -c "cd /modules/chado_custom_search && composer install && DRUPAL_ROOT=/var/www/html IS_TRAVIS=TRUE ./vendor/bin/phpunit --coverage-clover ./clover.xml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
 script:
   - docker run -it -d --rm --name tripal -v "$(pwd)":/modules/chado_custom_search statonlab/tripal3
   - sleep 45 # We pause here so postgres and apache complete booting up
+  - docker exec -it tripal cd modules && git clone https://github.com/tripal/trpdownload_api.git
   - docker exec -it tripal drush pm-enable -y chado_custom_search
   - docker exec -it tripal yum install -y php-pecl-xdebug.x86_64
   - docker exec -it tripal bash -c "cd /modules/chado_custom_search && composer install && DRUPAL_ROOT=/var/www/html IS_TRAVIS=TRUE ./vendor/bin/phpunit --coverage-clover ./clover.xml"

--- a/chado_custom_search/ChadoCustomSearch.inc
+++ b/chado_custom_search/ChadoCustomSearch.inc
@@ -288,17 +288,28 @@ class ChadoCustomSearch {
       </style>',
     ];
 
-    $links = [];
-    foreach ($class::$download_formats as $format) {
-      $path = $class::$menu['path'] . '/' . $format['path_ending'];
-      $link_title = $format['link_title'];
-      $links[] = l($link_title, $path, ['query' => $q]);
+    // ONLY ADD LINKS IF THE USER HAS PERMISSION TO ACCESS THEM.
+    if (user_access('chado_search_api download')) {
+
+      $links = [];
+      foreach ($class::$download_formats as $format) {
+        $path = $class::$menu['path'] . '/' . $format['path_ending'];
+        $link_title = $format['link_title'];
+        $links[] = l($link_title, $path, ['query' => $q]);
+      }
+      $content = implode(', ', $links);
+    }
+    elseif (user_is_anonymous()) {
+      $content = "<em>Requires log in</em>";
+    }
+    else {
+      $content = "<em>Requires permission</em>";
     }
 
     $form['download'] = [
       '#type' => 'markup',
       '#prefix' => '<div class="download-link"><strong>Download: </strong>',
-      '#markup' => implode(', ', $links),
+      '#markup' => $content,
       '#suffix' => '</div>',
       '#weight' => 29,
     ];

--- a/chado_custom_search/ChadoCustomSearch.inc
+++ b/chado_custom_search/ChadoCustomSearch.inc
@@ -108,6 +108,26 @@ class ChadoCustomSearch {
    */
   public static $button_text = 'Search';
 
+  /**
+   * Download formats available for this search. This is an array with the
+   * values describing each download page to link to.
+   */
+  public static $download_formats = [
+    [
+      // Optional: the machine name of the trpdownload_api integration.
+      'trpdownload_api' => 'chado_custom_search_csv',
+      // Required: the download page must be at [pathtosearch]/[unique ending]
+      // where the unique ending is specified here.
+      'path_ending' => 'csv',
+      // Required: The title to use for the link. This is best kept short.
+      'link_title' => 'CSV',
+    ],
+    [
+      'trpdownload_api' => 'chado_custom_search_tsv',
+      'path_ending' => 'tsv',
+      'link_title' => 'TSV',
+    ]];
+
   // --------------------------------------------------------------------------
   //                  PRIVATE MEMBERS -- DO NOT EDIT or OVERRIDE
   // --------------------------------------------------------------------------
@@ -238,6 +258,51 @@ class ChadoCustomSearch {
    *   The current offset. This is primarily used for pagers.
    */
   public function getQuery(&$query, &$args, $offset) {}
+
+  /**
+   * Formats the download formats into links to each download page.
+   *
+   * NOTE: This was designed with the Tripal Download API in mind but that is
+   * not a requirement for any custom formats
+   * though it is recommended for consistency.
+   *
+   * @param array $form
+   *   The current form array.
+   * @param array $q
+   *   The query parameters to pass on to the download page.
+   */
+  public function formatDownloadLinks(&$form, $q) {
+    $class = get_called_class();
+
+    $form['download_style'] = [
+      '#type' => 'markup',
+      '#markup' => '<style>
+        .download-link {
+          margin-left: 2px;
+          margin-top: 20px;
+          margin-bottom: 2px;
+        }
+        #chado-custom-search-form table {
+          margin-top: 0px;
+        }
+      </style>',
+    ];
+
+    $links = [];
+    foreach ($class::$download_formats as $format) {
+      $path = $class::$menu['path'] . '/' . $format['path_ending'];
+      $link_title = $format['link_title'];
+      $links[] = l($link_title, $path, ['query' => $q]);
+    }
+
+    $form['download'] = [
+      '#type' => 'markup',
+      '#prefix' => '<div class="download-link"><strong>Download: </strong>',
+      '#markup' => implode(', ', $links),
+      '#suffix' => '</div>',
+      '#weight' => 29,
+    ];
+  }
 
   /**
    * Format the results within the $form array.

--- a/chado_custom_search/chado_custom_search.info
+++ b/chado_custom_search/chado_custom_search.info
@@ -4,3 +4,4 @@ core = 7.x
 package = Chado Custom Search
 dependencies[] = tripal
 dependencies[] = tripal_chado
+dependencies[] = trpdownload_api

--- a/chado_custom_search/chado_custom_search.module
+++ b/chado_custom_search/chado_custom_search.module
@@ -39,7 +39,7 @@ function chado_custom_search_menu() {
       'title' => $class_name::$title . ': CSV',
       'page callback' => 'trpdownload_download_page',
       'page arguments' => ['chado_custom_search_csv'],
-      'access arguments' => ['access content'], //['chado_search_api download'],
+      'access arguments' => ['chado_search_api download'],
       'type' => MENU_CALLBACK,
     ];
 
@@ -48,13 +48,25 @@ function chado_custom_search_menu() {
       'title' => $class_name::$title . ': TSV',
       'page callback' => 'trpdownload_download_page',
       'page arguments' => ['chado_custom_search_tsv'],
-      'access arguments' => ['access content'], //['chado_search_api download'],
+      'access arguments' => ['chado_search_api download'],
       'type' => MENU_CALLBACK,
     ];
   }
 
   return $items;
 }
+
+/**
+ * Implements hook_permission().
+ */
+function chado_custom_search_permission() {
+  return array(
+    'chado_search_api download' => array(
+      'title' => t('Permission to download search results.'),
+    )
+  );
+}
+
 
 /**
  * Provides the search page for any chado custom search.

--- a/chado_custom_search/chado_custom_search.module
+++ b/chado_custom_search/chado_custom_search.module
@@ -67,7 +67,6 @@ function chado_custom_search_permission() {
   );
 }
 
-
 /**
  * Provides the search page for any chado custom search.
  *

--- a/chado_custom_search/chado_custom_search.module
+++ b/chado_custom_search/chado_custom_search.module
@@ -87,6 +87,9 @@ function chado_custom_search_form($form, &$form_state) {
   $class = $form_state['build_info']['args'][0];
   $search = new $class;
 
+  // Set the title as expected.
+  drupal_set_title($class::$title);
+
   // Save the class name for use in the submit.
   $form['class_name'] = [
     '#type' => 'hidden',

--- a/chado_custom_search/chado_custom_search.module
+++ b/chado_custom_search/chado_custom_search.module
@@ -7,6 +7,7 @@
 
 // Include the API.
 require_once 'chado_custom_search.api.inc';
+require_once 'includes/chado_search_api.download.inc';
 
 require_once 'ChadoCustomSearch.inc';
 require_once 'includes/TestSearch.inc';
@@ -32,6 +33,24 @@ function chado_custom_search_menu() {
       'type' => MENU_CALLBACK,
     ];
 
+    // DOWNLOADS:
+    // -- Comma-separated.
+    $items[$path . '/csv'] = [
+      'title' => $class_name::$title . ': CSV',
+      'page callback' => 'trpdownload_download_page',
+      'page arguments' => ['chado_custom_search_csv'],
+      'access arguments' => ['access content'], //['chado_search_api download'],
+      'type' => MENU_CALLBACK,
+    ];
+
+    // -- Tab-delimited.
+    $items[$path . '/tsv'] = [
+      'title' => $class_name::$title . ': TSV',
+      'page callback' => 'trpdownload_download_page',
+      'page arguments' => ['chado_custom_search_tsv'],
+      'access arguments' => ['access content'], //['chado_search_api download'],
+      'type' => MENU_CALLBACK,
+    ];
   }
 
   return $items;
@@ -118,6 +137,8 @@ function chado_custom_search_form($form, &$form_state) {
     $results = $search->getResults($offset);
 
     if ($results !== FALSE) {
+      $q['class'] = $class;
+      $search->formatDownloadLinks($form, $q);
       $search->formatResults($form, $results);
     }
   }

--- a/chado_custom_search/includes/chado_search_api.download.inc
+++ b/chado_custom_search/includes/chado_search_api.download.inc
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ *
+ */
+
+/**
+ * Implements hook_register_trpdownload_type().
+ */
+function chado_custom_search_register_trpdownload_type() {
+	$types = array();
+
+	// The key is the machine name of my download type.
+	$types['chado_custom_search_csv'] = [
+		// A human readable name to show in an administrative interface one day.
+		'type_name' => 'Chado Custom Search CSV',
+		// A human readable description of the format.
+		'format' => 'Comma-separated Values',
+		// An array of functions that the API will use to customize your experience.
+		'functions' => [
+			// The function that tripal jobs will call to generate the file.
+			'generate_file' => 'chado_custom_search_csv_generate_file',
+			// OPTIONAL: determine your own filename.
+			'get_filename' => 'chado_custom_search_get_filename',
+			// OPTIONAL: Change the file suffix (defaults to .txt)
+			'get_file_suffix' => 'chado_custom_search_csv_get_suffix',
+		],
+	];
+
+	// The key is the machine name of my download type.
+	$types['chado_custom_search_tsv'] = [
+		// A human readable name to show in an administrative interface one day.
+		'type_name' => 'Chado Custom Search TSV',
+		// A human readable description of the format.
+		'format' => 'Tab-delimited Values',
+		// An array of functions that the API will use to customize your experience.
+		'functions' => [
+			// The function that tripal jobs will call to generate the file.
+			'generate_file' => 'chado_custom_search_tsv_generate_file',
+			// OPTIONAL: determine your own filename.
+			'get_filename' => 'chado_custom_search_get_filename',
+			// OPTIONAL: Change the file suffix (defaults to .txt)
+			'get_file_suffix' => 'chado_custom_search_tsv_get_suffix',
+		],
+	];
+
+	return $types;
+}
+
+
+/**
+ * Generates a file for download in the specified format.
+ *
+ * @param $variables
+ *   An associative array of parameters including:
+ *     - q: all the query paramters.
+ *     - site_safe_name: a sanitized version of your site name for use in variables & filenames.
+ *     - type_info: an array of info for the download type.
+ *     - suffix: the file format suffix.
+ *     - filename: the filename of the file to generate not including path.
+ *     - fullpath: the full path and filename of the file to generate.
+ *     - format_name: a human-readable description of the format.
+ * @param $job_id
+ *   The ID of the tripal job executing this function ;-).
+ */
+function chado_custom_search_csv_generate_file($vars, $job_id = NULL) {
+  if (!isset($vars['drush'])) { $vars['drush'] = TRUE; }
+
+	// Create the file and ready it for writting to.
+  $filepath = variable_get('trpdownload_fullpath', '') . $vars['filename'];
+  if ($vars['drush']) { drush_print("File: " . $filepath); }
+  $FILE = fopen($filepath, 'w') or die ("Unable to create file to write to.\n");
+
+}
+
+/**
+ * Generates a file for download in the specified format.
+ *
+ * @param $variables
+ *   An associative array of parameters including:
+ *     - q: all the query paramters.
+ *     - site_safe_name: a sanitized version of your site name for use in variables & filenames.
+ *     - type_info: an array of info for the download type.
+ *     - suffix: the file format suffix.
+ *     - filename: the filename of the file to generate not including path.
+ *     - fullpath: the full path and filename of the file to generate.
+ *     - format_name: a human-readable description of the format.
+ * @param $job_id
+ *   The ID of the tripal job executing this function ;-).
+ */
+function chado_custom_search_tsv_generate_file($vars, $job_id = NULL) {
+  if (!isset($vars['drush'])) { $vars['drush'] = TRUE; }
+
+	// Create the file and ready it for writting to.
+  $filepath = variable_get('trpdownload_fullpath', '') . $vars['filename'];
+  if ($vars['drush']) { drush_print("File: " . $filepath); }
+  $FILE = fopen($filepath, 'w') or die ("Unable to create file to write to.\n");
+
+}
+
+/**
+ * Generate a readable and unique filename for the file to be generated.
+ */
+function chado_custom_search_get_filename($vars) {
+  $filename = $vars['download_args']['safe_site_name'] .'.searchresults.' . date('YMj-his');
+  return $filename;
+}
+
+/**
+ * Determine the file suffix for the file to be generated.
+ */
+function chado_custom_search_csv_get_suffix($vars) {
+  return 'csv';
+}
+
+/**
+ * Determine the file suffix for the file to be generated.
+ */
+function chado_custom_search_tsv_get_suffix($vars) {
+  return 'tsv';
+}

--- a/chado_custom_search/includes/chado_search_api.download.inc
+++ b/chado_custom_search/includes/chado_search_api.download.inc
@@ -1,50 +1,53 @@
 <?php
 
 /**
+ * @file
  *
+ * Implements the Tripal Download API to provide CSV and TSV downloads for
+ * ALL chado custom searches.
  */
 
 /**
  * Implements hook_register_trpdownload_type().
  */
 function chado_custom_search_register_trpdownload_type() {
-	$types = array();
+  $types = array();
 
-	// The key is the machine name of my download type.
-	$types['chado_custom_search_csv'] = [
-		// A human readable name to show in an administrative interface one day.
-		'type_name' => 'Chado Custom Search CSV',
-		// A human readable description of the format.
-		'format' => 'Comma-separated Values',
-		// An array of functions that the API will use to customize your experience.
-		'functions' => [
-			// The function that tripal jobs will call to generate the file.
-			'generate_file' => 'chado_custom_search_csv_generate_file',
-			// OPTIONAL: determine your own filename.
-			'get_filename' => 'chado_custom_search_get_filename',
-			// OPTIONAL: Change the file suffix (defaults to .txt)
-			'get_file_suffix' => 'chado_custom_search_csv_get_suffix',
-		],
-	];
+  // The key is the machine name of my download type.
+  $types['chado_custom_search_csv'] = [
+    // A human readable name to show in an administrative interface one day.
+    'type_name' => 'Chado Custom Search CSV',
+    // A human readable description of the format.
+    'format' => 'Comma-separated Values',
+    // An array of functions that the API will use to customize your experience.
+    'functions' => [
+      // The function that tripal jobs will call to generate the file.
+      'generate_file' => 'chado_custom_search_csv_generate_file',
+      // OPTIONAL: determine your own filename.
+      'get_filename' => 'chado_custom_search_get_filename',
+      // OPTIONAL: Change the file suffix (defaults to .txt)
+      'get_file_suffix' => 'chado_custom_search_csv_get_suffix',
+    ],
+  ];
 
-	// The key is the machine name of my download type.
-	$types['chado_custom_search_tsv'] = [
-		// A human readable name to show in an administrative interface one day.
-		'type_name' => 'Chado Custom Search TSV',
-		// A human readable description of the format.
-		'format' => 'Tab-delimited Values',
-		// An array of functions that the API will use to customize your experience.
-		'functions' => [
-			// The function that tripal jobs will call to generate the file.
-			'generate_file' => 'chado_custom_search_tsv_generate_file',
-			// OPTIONAL: determine your own filename.
-			'get_filename' => 'chado_custom_search_get_filename',
-			// OPTIONAL: Change the file suffix (defaults to .txt)
-			'get_file_suffix' => 'chado_custom_search_tsv_get_suffix',
-		],
-	];
+  // The key is the machine name of my download type.
+  $types['chado_custom_search_tsv'] = [
+    // A human readable name to show in an administrative interface one day.
+    'type_name' => 'Chado Custom Search TSV',
+    // A human readable description of the format.
+    'format' => 'Tab-delimited Values',
+    // An array of functions that the API will use to customize your experience.
+    'functions' => [
+      // The function that tripal jobs will call to generate the file.
+      'generate_file' => 'chado_custom_search_tsv_generate_file',
+      // OPTIONAL: determine your own filename.
+      'get_filename' => 'chado_custom_search_get_filename',
+      // OPTIONAL: Change the file suffix (defaults to .txt)
+      'get_file_suffix' => 'chado_custom_search_tsv_get_suffix',
+    ],
+  ];
 
-	return $types;
+  return $types;
 }
 
 
@@ -66,11 +69,101 @@ function chado_custom_search_register_trpdownload_type() {
 function chado_custom_search_csv_generate_file($vars, $job_id = NULL) {
   if (!isset($vars['drush'])) { $vars['drush'] = TRUE; }
 
-	// Create the file and ready it for writting to.
+  // Create the file and ready it for writting to.
   $filepath = variable_get('trpdownload_fullpath', '') . $vars['filename'];
   if ($vars['drush']) { drush_print("File: " . $filepath); }
   $FILE = fopen($filepath, 'w') or die ("Unable to create file to write to.\n");
 
+  // First pull out our query paramters.
+  $q = $vars['q'];
+
+  // Next, create an instance of the class to query.
+  $class = $vars['q']['class'];
+  $search = new $class;
+
+  // Compile our values array based on paramters.
+  $doQuery = FALSE;
+  $values = NULL;
+  if ($search::$require_submit == FALSE) {
+    $doQuery = TRUE;
+
+    // Ensure that initial query takes into account URL parameters if present.
+    $values = [];
+    foreach ($class::$info['filters'] as $name => $details) {
+      if (isset($q[$name])) {
+        $values[$name] = $q[$name];
+      }
+    }
+  }
+  elseif(!empty($q)) {
+    $doQuery = TRUE;
+
+    // Ensure that initial query takes into account URL parameters if present.
+    $values = [];
+    foreach ($class::$info['filters'] as $name => $details) {
+      if (isset($q[$name])) {
+        $values[$name] = $q[$name];
+      }
+    }
+  }
+  else {
+    tripal_report_error(
+      'chado_search_api',
+      TRIPAL_ERROR,
+      "Unable to download data for job :id as there were no values supplied.",
+      [':id' => $job_id]
+    );
+  }
+
+  // Now, query the database for the results.
+  if ($doQuery) {
+
+    // First set the filter criteria for our search.
+    $search->setValues($values, TRUE);
+    // Now ensure we start with the first page.
+    $offset = 0;
+
+    // Now, we start our loop to page through the results.
+    do {
+      // Retrieve the results for the current page.
+      $results = $search->getResults($offset);
+
+      // First generate the header and the template row.
+      $header = [];
+      $template_row = [];
+      foreach ($class::$info['fields'] as $name => $details) {
+        $header[$name] = $details['title'];
+        $template_row[$name] = '';
+      }
+
+      // If this is the first page then print the header.
+      if ($offset == 0) {
+        fputcsv($FILE, $header);
+      }
+
+      // Now compile each row from the results.
+      $num_rows = 0;
+      foreach ($results as $r) {
+        $num_rows++;
+        $row = [];
+        foreach ($template_row as $key => $default) {
+          if (isset($r->{$key})) {
+            $row[$key] = $r->{$key};
+          }
+          else {
+            $row[$key] = '';
+          }
+        }
+        fputcsv($FILE, $row);
+      }
+
+      // Finally, flip to the next page by increasing the offset
+      // by the number of records we've processed.
+      $offset = $offset + $num_rows;
+
+    // Now we loop to the next page, assuming this wasn't the last page.
+    } while ($num_rows != 0);
+  }
 }
 
 /**
@@ -91,11 +184,101 @@ function chado_custom_search_csv_generate_file($vars, $job_id = NULL) {
 function chado_custom_search_tsv_generate_file($vars, $job_id = NULL) {
   if (!isset($vars['drush'])) { $vars['drush'] = TRUE; }
 
-	// Create the file and ready it for writting to.
+  // Create the file and ready it for writting to.
   $filepath = variable_get('trpdownload_fullpath', '') . $vars['filename'];
   if ($vars['drush']) { drush_print("File: " . $filepath); }
   $FILE = fopen($filepath, 'w') or die ("Unable to create file to write to.\n");
 
+  // First pull out our query paramters.
+  $q = $vars['q'];
+
+  // Next, create an instance of the class to query.
+  $class = $vars['q']['class'];
+  $search = new $class;
+
+  // Compile our values array based on paramters.
+  $doQuery = FALSE;
+  $values = NULL;
+  if ($search::$require_submit == FALSE) {
+    $doQuery = TRUE;
+
+    // Ensure that initial query takes into account URL parameters if present.
+    $values = [];
+    foreach ($class::$info['filters'] as $name => $details) {
+      if (isset($q[$name])) {
+        $values[$name] = $q[$name];
+      }
+    }
+  }
+  elseif(!empty($q)) {
+    $doQuery = TRUE;
+
+    // Ensure that initial query takes into account URL parameters if present.
+    $values = [];
+    foreach ($class::$info['filters'] as $name => $details) {
+      if (isset($q[$name])) {
+        $values[$name] = $q[$name];
+      }
+    }
+  }
+  else {
+    tripal_report_error(
+      'chado_search_api',
+      TRIPAL_ERROR,
+      "Unable to download data for job :id as there were no values supplied.",
+      [':id' => $job_id]
+    );
+  }
+
+  // Now, query the database for the results.
+  if ($doQuery) {
+
+    // First set the filter criteria for our search.
+    $search->setValues($values, TRUE);
+    // Now ensure we start with the first page.
+    $offset = 0;
+
+    // Now, we start our loop to page through the results.
+    do {
+      // Retrieve the results for the current page.
+      $results = $search->getResults($offset);
+
+      // First generate the header and the template row.
+      $header = [];
+      $template_row = [];
+      foreach ($class::$info['fields'] as $name => $details) {
+        $header[$name] = $details['title'];
+        $template_row[$name] = '';
+      }
+
+      // If this is the first page then print the header.
+      if ($offset == 0) {
+        fwrite($FILE, implode("\t", $header) . "\n");
+      }
+
+      // Now compile each row from the results.
+      $num_rows = 0;
+      foreach ($results as $r) {
+        $num_rows++;
+        $row = [];
+        foreach ($template_row as $key => $default) {
+          if (isset($r->{$key})) {
+            $row[$key] = $r->{$key};
+          }
+          else {
+            $row[$key] = '';
+          }
+        }
+        fwrite($FILE, implode("\t", $row) . "\n");
+      }
+
+      // Finally, flip to the next page by increasing the offset
+      // by the number of records we've processed.
+      $offset = $offset + $num_rows;
+
+    // Now we loop to the next page, assuming this wasn't the last page.
+    } while ($num_rows != 0);
+  }
 }
 
 /**

--- a/docs/editable-constants.rst
+++ b/docs/editable-constants.rst
@@ -40,7 +40,7 @@ The machine names of the permissions with access to this search. This is used to
 
   public static $permissions = ['access content'];
 
-If you want to use custom permissions, make sure to defined them first in your module file using `hook_permission() <https://www.drupal.org/docs/7/creating-custom-modules/specifying-a-custom-permission-for-a-new-page#custom-permission>`_.
+If you want to use custom permissions, make sure to define them first in your module file using `hook_permission() <https://www.drupal.org/docs/7/creating-custom-modules/specifying-a-custom-permission-for-a-new-page#custom-permission>`_.
 
 Require Submit
 ----------------
@@ -58,7 +58,7 @@ If TRUE, this search will require the submit button to be clicked before executi
 Paging
 -------
 
-If ``$pager`` is true, the API will add a simple pager to your search results with a previous and next page link as well as indication of what page they are on. A simple pager is used for speed since it doesn't require counting the search results which is notoriously slow in PostgreSQL. You can also control the number of items per page using ``$num_items_per_page``.
+If ``$pager`` is TRUE, the API will add a simple pager to your search results with a previous and next page link as well as indication of what page they are on. A simple pager is used for speed since it doesn't require counting the search results which is notoriously slow in PostgreSQL. You can also control the number of items per page using ``$num_items_per_page``.
 
 .. code-block:: php
 
@@ -67,7 +67,7 @@ If ``$pager`` is true, the API will add a simple pager to your search results wi
 
 .. note::
 
-  The API handles genering the pager on the search page, determining which links should be available and changing the filter values to keep track of the page. **You need to ensure your getQuery() method returns the appropriate results for a given page.**
+  The API handles adding the pager to the search page. This includes determining which links should be available and changing the filter values to keep track of the page. **You need to ensure your getQuery() method returns the appropriate results for a given page.**
 
 Menu
 ------

--- a/example_ccsearch/examples/BreedingCrossSearch.inc
+++ b/example_ccsearch/examples/BreedingCrossSearch.inc
@@ -34,7 +34,7 @@ class BreedingCrossSearch extends ChadoCustomSearch {
   public static $permissions = ['access content'];
 
   /**
-   * This defined the hook_menu definition for this search. At a minimum the
+   * This defines the hook_menu definition for this search. At a minimum the
    * path is required.
    */
   public static $menu = [
@@ -48,9 +48,15 @@ class BreedingCrossSearch extends ChadoCustomSearch {
   public static $info = [
     // Lists the columns in your results table.
     'fields' => [
-      'child_name' => 'Cross Name',
-      'mom_name' => 'Maternal Parent',
-      'dad_name' => 'Paternal Parent',
+      'child_name' => [
+        'title' => 'Cross Name'
+      ],
+      'mom_name' => [
+        'title' => 'Maternal Parent'
+      ],
+      'dad_name' => [
+        'title' => 'Paternal Parent'
+      ],
     ],
     // The filter criteria available to the user.
     // This is used to generate a search form which can be altered.
@@ -77,6 +83,12 @@ class BreedingCrossSearch extends ChadoCustomSearch {
   public static $button_text = 'Search';
 
   /**
+   * Indicates whether to show results when the page is first loaded (FALSE)
+   * or whether to require users click the submit button (TRUE).
+   */
+  public static $require_submit = TRUE;
+
+  /**
    * Determine the query for the breeding cross search.
    *
    * Searches for the parents of a given cross. It can be filtered by cross
@@ -91,8 +103,10 @@ class BreedingCrossSearch extends ChadoCustomSearch {
    * @param array $args
    *   An array of arguments to pass to chado_query(). Keys must be the
    *   placeholders in the query and values should be what you want them set to.
+   * @param integer $offset
+   *   The number of records to offset for the results. This is used in paging.
    */
-  public function getQuery(&$query, &$args) {
+  public function getQuery(&$query, &$args, $offset) {
 
     // Retrieve the filter results already set.
     $filter_results = $this->values;
@@ -131,6 +145,11 @@ class BreedingCrossSearch extends ChadoCustomSearch {
     }
 
     $query .= ' ORDER BY child.name ASC';
+
+    // Add the offset to the query for paging.
+    if ($offset and is_numeric($offset)) {
+      $query .= 'OFFSET ' . $offset;
+    }
     $query .= ' LIMIT 50';
   }
 }


### PR DESCRIPTION
This PR adds download support to all searches made with the Chado Search API. It does so using the Tripal Download API which is now a dependency of this module.

 ## Setup
1. install Tripal Download API
2. checkout this branch. 
Now all searches will have download functionality.

## Testing
 - You should only be able to download results if you have the Chado Search API download permission. If you are not logged in you will be told you need to and if you are logged on but don't have the permission then you will be told you require permission.
- Download links will download all results not just the current page.
- If you are on the second page, it should still download the full result set.

NOTE: Tripal Download API is already installed on KnowPulse clones. Also, all germplasm searches and the marker search are implemented using the chado search api.