### PR TITLE
G3.5 Study/Experiment Search

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,12 +3,12 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "drupalversion": "11.1.x-dev",
+      "drupalversion": "11.x-dev",
       "phpversion": "8.3",
       "pgsqlversion": "16"
     }
   },
-  "initializeCommand": "docker pull knowpulse/tripalcultivate-tripal:drupal11.1.x-dev-php8.3-pgsql16",
+  "initializeCommand": "docker pull knowpulse/tripalcultivate-base:drupal11.1.x-dev-php8.3-pgsql16",
   "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/TripalCultivate-ChadoSearch,type=bind",
   "workspaceFolder": "/var/www/drupal/web/modules/contrib/TripalCultivate-ChadoSearch",
   "customizations": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG drupalversion=11.1.x-dev
 ARG phpversion=8.3
 ARG pgsqlversion=16
-FROM knowpulse/tripalcultivate-tripal:drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
+FROM knowpulse/tripalcultivate-base:drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
 
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-ChadoSearch
 WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-ChadoSearch
 
 RUN service postgresql start \
-  && drush en trpcultivate_chadosearch example_ccsearch --yes \
+  && drush en trpcultivate_chadosearch search_research --yes \
   && drush tripal:trp-run-jobs --username=drupaladmin \
   && drush cr \
   && service postgresql stop

--- a/example_ccsearch/src/Plugin/ChadoSearch/BreedingCrossSearch.php
+++ b/example_ccsearch/src/Plugin/ChadoSearch/BreedingCrossSearch.php
@@ -28,7 +28,7 @@ class BreedingCrossSearch extends ChadoSearchPluginBase implements ChadoSearchIn
    *
    * @var array
    */
-  public static $info = [
+  public static array $info = [
     // Lists the columns in your results table.
     'fields' => [
       'cross_name' => [

--- a/search_research/search_research.info.yml
+++ b/search_research/search_research.info.yml
@@ -1,0 +1,7 @@
+name: "Research Management Searches"
+type: module
+description: Provides a collection of searches focused on research management including ones for grants and studies.
+core_version_requirement: ^10 | ^11
+dependencies:
+  - "tripal:tripal"
+  - "tripal:tripal_chado"

--- a/search_research/search_research.module
+++ b/search_research/search_research.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Contains all hook implementations for this module.
+ */

--- a/search_research/src/Plugin/ChadoSearch/ResearchStudySearch.php
+++ b/search_research/src/Plugin/ChadoSearch/ResearchStudySearch.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\search_research\Plugin\ChadoSearch;
+
+use Drupal\trpcultivate_chadosearch\ChadoSearch\Interfaces\ChadoSearchInterface;
+use Drupal\trpcultivate_chadosearch\ChadoSearch\ChadoSearchPluginBase;
+
+/**
+ * Creates a search for research studies and their associated experiments.
+ *
+ *  @ChadoSearch(
+ *    id = "research_study",
+ *    title = @Translation("Research Studies"),
+ *    description = @Translation("Explore ongoing and past research studies and their associated experiments."),
+ *    permissions = {"access content"},
+ *    url_path = "research-study/search",
+ *    button_text = @Translation("Search"),
+ *    require_submit = FALSE,
+ *    pager = TRUE,
+ *    num_items_per_page = 25,
+ *  )
+ */
+class ResearchStudySearch extends ChadoSearchPluginBase implements ChadoSearchInterface {
+
+}

--- a/search_research/src/Plugin/ChadoSearch/ResearchStudySearch.php
+++ b/search_research/src/Plugin/ChadoSearch/ResearchStudySearch.php
@@ -22,4 +22,178 @@ use Drupal\trpcultivate_chadosearch\ChadoSearch\ChadoSearchPluginBase;
  */
 class ResearchStudySearch extends ChadoSearchPluginBase implements ChadoSearchInterface {
 
+  /**
+   * Information regarding the fields and filters for this search.
+   *
+   * @var array
+   */
+  public static array $info = [
+    // Lists the columns in your results table.
+    'fields' => [
+      'name' => [
+        'title' => 'Name',
+        'entity_link' => [
+          'chado_table' => 'project',
+          'id_column' => 'project_id',
+        ],
+      ],
+      'genus' => [
+        'title' => 'Genus',
+      ],
+      'year' => [
+        'title' => 'Dates',
+      ],
+      'category' => [
+        'title' => 'Category',
+      ],
+    ],
+    // The filter criteria available to the user.
+    // This is used to generate a search form which can be altered.
+    'filters' => [
+      'genus' => [
+        'title' => 'Genus',
+        'help' => 'The legume species the research study is focused on (e.g. Lens culinaris).',
+        'default' => 'Lens',
+      ],
+      'species' => [
+        'title' => 'Species',
+        'help' => '',
+      ],
+      'name' => [
+        'title' => 'Name',
+        'help' => 'The name of the research study you are interested in (partial names are accepted).',
+      ],
+    ],
+  ];
+
+  /**
+   * Determine the query for the research study search.
+   *
+   * @param Drupal\Core\Database\Query\Select|null $query
+   *   A Drupal select query object used to retrieve the results.
+   *   This parameter will be NULL when requested and initialized inside
+   *   this method.
+   * @param int $offset
+   *   The number of records to offset for the results. This is used in paging.
+   */
+  public function getQuery(Select|null &$query, int $offset = 0) {
+
+    // Retrieve the filter results already set.
+    $filter_results = $this->values;
+
+    // @todo Collaborators: 5311
+    $query = "
+      SELECT
+        exp.name, exp.project_id,
+        exp.description,
+        genus.value as genus,
+        yr.value as year,
+        cat.value as category
+      FROM {project} exp
+      LEFT JOIN {projectprop} genus ON genus.project_id=exp.project_id
+        AND genus.type_id=4032 AND genus.rank=0
+      LEFT JOIN {projectprop} yr ON yr.project_id=exp.project_id
+        AND yr.type_id=6364 AND yr.rank=0
+      LEFT JOIN {projectprop} cat ON cat.project_id=exp.project_id
+        AND cat.type_id=6365 AND cat.rank=0
+      LEFT JOIN {projectprop} re ON re.project_id=exp.project_id
+        AND re.type_id=4310 AND re.rank=0";
+
+    $where = [];
+    $joins = [];
+
+    $where[] = "re.value = :content_type";
+    $args[':content_type'] = 'SIO:Study';
+    // -- Genus.
+    if ($filter_results['genus'] != '') {
+      $where[] = "genus.value ~* :genus";
+      $args[':genus'] = $filter_results['genus'];
+    }
+
+    // -- Species.
+    if ($filter_results['species'] != '') {
+      $where[] = "species.value ~* :species";
+      $args[':species'] = $filter_results['species'];
+    }
+
+    // -- Name.
+    if ($filter_results['name'] != '') {
+      $where[] = "exp.name ~* :name";
+      $args[':name'] = $filter_results['name'];
+    }
+
+    // Finally, add it to the query.
+    if (!empty($joins)) {
+      $query .= implode("\n", $joins);
+    }
+    if (!empty($where)) {
+      $query .= "\n" . ' WHERE ' . implode(' AND ', $where);
+    }
+
+    // Sort even though it is SLOW b/c ppl expect it.
+    $query .= "\n" . ' ORDER BY substring(yr.value, 6, 9) DESC, exp.name ASC';
+
+    // Handle paging.
+    $limit = $this::$num_items_per_page + 1;
+    $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
+
+    // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formatResults(array &$form, array $results): void {
+    $list = [];
+
+    foreach ($results as $r) {
+      // Add a link to the title.
+      $title = $r->name;
+      $id = NULL;
+      if ($r->project_id) {
+        $id = chado_get_record_entity_by_table('project', $r->project_id);
+        if ($id) {
+          $title = l($r->name, 'bio_data/' . $id);
+        }
+      }
+
+      // Substring the description.
+      $description = strip_tags($r->description);
+      if (preg_match('/^.{1,300}\b/s', $description, $match)) {
+        $description = trim($match[0]);
+      }
+      if ($id && (strlen($description) > 0)) {
+        $description .= ' ' . l('[Read more]', 'bio_data/' . $id);
+      }
+
+      $markup = '
+        <div class="result-row">
+          <div class="result-left">
+            <div class="result-title">' . $title . '</div>
+            <div class="result-description">' . $description . '</div>
+          </div>
+	  <div class="result-right">';
+      if ($r->year) {
+        $markup .= '<div class="result-year" title="Year(s) of Funding">' . $r->year . '</div>';
+      }
+      if ($r->genus) {
+        $markup .= '<div class="result-genus" title="Genus for germplasm">' . $r->genus . '</div>';
+      }
+      if ($r->category) {
+        $markup .= '<div class="result-category" title="Research Category">' . $r->category . '</div>';
+      }
+      $markup .= '
+          </div>
+        </div>';
+      $list[] = $markup;
+    }
+
+    $form['results'] = [
+      '#theme' => 'item_list',
+      '#items' => $list,
+      '#type' => 'ul',
+      '#weight' => 50,
+    ];
+  }
+
 }

--- a/search_research/src/Plugin/ChadoSearch/ResearchStudySearch.php
+++ b/search_research/src/Plugin/ChadoSearch/ResearchStudySearch.php
@@ -4,6 +4,7 @@ namespace Drupal\search_research\Plugin\ChadoSearch;
 
 use Drupal\trpcultivate_chadosearch\ChadoSearch\Interfaces\ChadoSearchInterface;
 use Drupal\trpcultivate_chadosearch\ChadoSearch\ChadoSearchPluginBase;
+use Drupal\Core\Database\Query\Select;
 
 /**
  * Creates a search for research studies and their associated experiments.
@@ -53,11 +54,6 @@ class ResearchStudySearch extends ChadoSearchPluginBase implements ChadoSearchIn
       'genus' => [
         'title' => 'Genus',
         'help' => 'The legume species the research study is focused on (e.g. Lens culinaris).',
-        'default' => 'Lens',
-      ],
-      'species' => [
-        'title' => 'Species',
-        'help' => '',
       ],
       'name' => [
         'title' => 'Name',
@@ -81,89 +77,109 @@ class ResearchStudySearch extends ChadoSearchPluginBase implements ChadoSearchIn
     // Retrieve the filter results already set.
     $filter_results = $this->values;
 
-    // @todo Collaborators: 5311
-    $query = "
-      SELECT
-        exp.name, exp.project_id,
-        exp.description,
-        genus.value as genus,
-        yr.value as year,
-        cat.value as category
-      FROM {project} exp
-      LEFT JOIN {projectprop} genus ON genus.project_id=exp.project_id
-        AND genus.type_id=4032 AND genus.rank=0
-      LEFT JOIN {projectprop} yr ON yr.project_id=exp.project_id
-        AND yr.type_id=6364 AND yr.rank=0
-      LEFT JOIN {projectprop} cat ON cat.project_id=exp.project_id
-        AND cat.type_id=6365 AND cat.rank=0
-      LEFT JOIN {projectprop} re ON re.project_id=exp.project_id
-        AND re.type_id=4310 AND re.rank=0";
+    $query = $this->chado_connection->select('1:project', 'study');
+    $query->fields('study', ['project_id', 'name', 'description']);
+    $query->condition('study.type_id', $this->getType('SIO', '001066'), 'IN');
 
-    $where = [];
-    $joins = [];
+    // Add Genus to the query.
+    $query->addJoin(
+      'LEFT',
+      '1:projectprop',
+      'genus',
+      'genus.project_id=study.project_id',
+    );
+    $query->condition('genus.type_id', $this->getType('TAXRANK', '0000005'), 'IN');
+    $query->addField('genus', 'value', 'genus');
 
-    $where[] = "re.value = :content_type";
-    $args[':content_type'] = 'SIO:Study';
+    // Add Year to the query.
+    $query->addJoin(
+      'LEFT',
+      '1:projectprop',
+      'year',
+      'year.project_id=study.project_id',
+    );
+    $query->condition('year.type_id', $this->getType('NCIT', 'C29848'), 'IN');
+    $query->addField('year', 'value', 'year');
+
     // -- Genus.
     if ($filter_results['genus'] != '') {
-      $where[] = "genus.value ~* :genus";
-      $args[':genus'] = $filter_results['genus'];
-    }
-
-    // -- Species.
-    if ($filter_results['species'] != '') {
-      $where[] = "species.value ~* :species";
-      $args[':species'] = $filter_results['species'];
+      $query->condition('genus.value', $filter_results['genus'], '~*');
     }
 
     // -- Name.
     if ($filter_results['name'] != '') {
-      $where[] = "exp.name ~* :name";
-      $args[':name'] = $filter_results['name'];
-    }
-
-    // Finally, add it to the query.
-    if (!empty($joins)) {
-      $query .= implode("\n", $joins);
-    }
-    if (!empty($where)) {
-      $query .= "\n" . ' WHERE ' . implode(' AND ', $where);
+      $query->condition('study.name', $filter_results['name'], '~*');
     }
 
     // Sort even though it is SLOW b/c ppl expect it.
-    $query .= "\n" . ' ORDER BY substring(yr.value, 6, 9) DESC, exp.name ASC';
+    $query->addExpression('substring(year.value, 6, 9)', 'shortened_year');
+    $query->orderBy('shortened_year', 'DESC');
+    $query->orderBy('study.name', 'ASC');
 
-    // Handle paging.
-    $limit = $this::$num_items_per_page + 1;
-    $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
+    // Add the offset to the query for paging.
+    if ($offset and is_numeric($offset)) {
+      $query->range($offset, 26);
+    }
+    else {
+      $query->range(0, 26);
+    }
 
-    // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+
+  /**
+   * Retrieve the cvterm ID for the given accession.
+   *
+   * @param string $idSpace
+   *   The ID Space of the term you want to retrieve the cvterm_id for.
+   * @param string $accession
+   *   The accession of the term you want to retrieve the cvterm_id for.
+   *
+   * @return int
+   *   The cvterm_id of the term we want to retrieve.
+   */
+  public function getType(string $idSpace, string $accession): int {
+    $query = $this->chado_connection->select('1:cvterm', 'cvt')
+      ->fields('cvt', ['cvterm_id']);
+
+    $query->addJoin(
+      'LEFT',
+      '1:dbxref',
+      'dbx',
+      'dbx.dbxref_id=cvt.dbxref_id',
+    );
+    $query->condition('dbx.accession', $accession);
+
+    $query->addJoin(
+      'LEFT',
+      '1:db',
+      'db',
+      'db.db_id=dbx.db_id',
+    );
+    $query->condition('db.name', $idSpace);
+
+    $result = $query->execute();
+    return $result->fetchField();
   }
 
   /**
    * {@inheritdoc}
+   *
+   * @todo Add content type linking for the study titles.
+   * @todo Add a read more link at the end of a shortened description.
+   * @todo Add styling to the results.
+   * @todo Update the elements to use nested render arrays rather then
+   *   concatenating HTML strings together.
    */
   public function formatResults(array &$form, array $results): void {
     $list = [];
 
     foreach ($results as $r) {
-      // Add a link to the title.
       $title = $r->name;
-      $id = NULL;
-      if ($r->project_id) {
-        $id = chado_get_record_entity_by_table('project', $r->project_id);
-        if ($id) {
-          $title = l($r->name, 'bio_data/' . $id);
-        }
-      }
 
       // Substring the description.
       $description = strip_tags($r->description);
       if (preg_match('/^.{1,300}\b/s', $description, $match)) {
         $description = trim($match[0]);
-      }
-      if ($id && (strlen($description) > 0)) {
-        $description .= ' ' . l('[Read more]', 'bio_data/' . $id);
       }
 
       $markup = '
@@ -173,19 +189,22 @@ class ResearchStudySearch extends ChadoSearchPluginBase implements ChadoSearchIn
             <div class="result-description">' . $description . '</div>
           </div>
 	  <div class="result-right">';
-      if ($r->year) {
+      if (isset($r->year)) {
         $markup .= '<div class="result-year" title="Year(s) of Funding">' . $r->year . '</div>';
       }
-      if ($r->genus) {
+      if (isset($r->genus)) {
         $markup .= '<div class="result-genus" title="Genus for germplasm">' . $r->genus . '</div>';
       }
-      if ($r->category) {
+      if (isset($r->category)) {
         $markup .= '<div class="result-category" title="Research Category">' . $r->category . '</div>';
       }
       $markup .= '
           </div>
         </div>';
-      $list[] = $markup;
+      $list[] = [
+        '#type' => 'markup',
+        '#markup' => $markup,
+      ];
     }
 
     $form['results'] = [

--- a/src/ChadoSearch/ChadoSearchPluginBase.php
+++ b/src/ChadoSearch/ChadoSearchPluginBase.php
@@ -30,7 +30,7 @@ abstract class ChadoSearchPluginBase extends PluginBase implements ChadoSearchIn
    *
    * @var array
    */
-  public static $info = [
+  public static array $info = [
     // Lists the columns in your results table.
     'fields' => [
       'column_name' => [

--- a/tests/src/Fixtures/ChadoSearchBasicallyBase.php
+++ b/tests/src/Fixtures/ChadoSearchBasicallyBase.php
@@ -42,7 +42,7 @@ class ChadoSearchBasicallyBase extends ChadoSearchPluginBase implements ChadoSea
    *
    * @var array
    */
-  public static $info = [
+  public static array $info = [
     // Lists the columns in your results table.
     'fields' => [
       'column1' => [

--- a/tests/src/Fixtures/ChadoSearchExactly2Pages.php
+++ b/tests/src/Fixtures/ChadoSearchExactly2Pages.php
@@ -42,7 +42,7 @@ class ChadoSearchExactly2Pages extends ChadoSearchPluginBase implements ChadoSea
    *
    * @var array
    */
-  public static $info = [
+  public static array $info = [
     // Lists the columns in your results table.
     'fields' => [
       'column1' => [

--- a/tests/src/Fixtures/ChadoSearchLess1Page.php
+++ b/tests/src/Fixtures/ChadoSearchLess1Page.php
@@ -42,7 +42,7 @@ class ChadoSearchLess1Page extends ChadoSearchPluginBase implements ChadoSearchI
    *
    * @var array
    */
-  public static $info = [
+  public static array $info = [
     // Lists the columns in your results table.
     'fields' => [
       'column1' => [


### PR DESCRIPTION
**Issue #5**

## Motivation
Upgrade the existing Tripal 3, KnowPulse-specific Study search to work on Tripal 4. Additionally make it generic for use on more websites.

The original search can be found here: https://github.com/UofS-Pulse-Binfo/kp_searches/blob/master/includes/ResearchStudySearch.inc

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Create a module for Research Management Searches
- [x] Update docker to install base module so we have access to these content types.
- [ ] Upgrade the Tripal 3 ResearchStudySearch class
- [ ] Create a method to generate research studies to test the class
- [ ] Add automated testing for this search

## Testing

### Automated Testing
<!-- Please describe each automated test this PR creates
     and provide a list of the assertions it makes using casual language.
     Do not just say things like "asserts the array is not empty"
     but rather say "Ensures that the return value of method X
     with these parameters is not an empty array". -->



### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

1. Start a fresh docker image/container on this branch. **You can use the devcontainer approach OR the following commands:**
  ```
  cd ~/Dockers
  git clone https://github.com/TripalCultivate/TripalCultivate-ChadoSearch trpcultSearch-6
  git checkout g3.5-upgradeStudySearch
  cd trpcultSearch-6
  docker build --tag=trpcultivate-search:review6 ./
  docker run --publish=80:80 -tid --name=search6 --volume=`pwd`:/var/www/drupal/web/modules/contrib/TripalCultivate-ChadoSearch trpcultivate-search:review6
  ```

2.
3.
